### PR TITLE
deps: update bun to 1.3.14

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "connect",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "fix": "biome check --write",
     "test": "TZ=Greenwich vitest"
   },
-  "packageManager": "bun@1.2.9",
+  "packageManager": "bun@1.3.14",
   "type": "module",
   "//devDependencies": {
     "@biomejs/biome": "code formatter and linter",


### PR DESCRIPTION
Bump `packageManager` from bun 1.2.9 to 1.3.14. The lockfile gains a `configVersion` field introduced in the newer format.